### PR TITLE
Hotfix Casos Test

### DIFF
--- a/test/test_yatzy_from_scratch.py
+++ b/test/test_yatzy_from_scratch.py
@@ -138,8 +138,8 @@ def test_smallStraight():
 @pytest.mark.test_largeStraight
 def test_largeStraight():
 
-    assert 20 == Yatzy.smallStraight(2,3,4,5,6)
-    assert 0 == Yatzy.smallStraight(2,3,4,5,5)
+    assert 20 == Yatzy.largeStraight(2,3,4,5,6)
+    assert 0 == Yatzy.largeStraight(2,3,4,5,5)
 
 
 


### PR DESCRIPTION
# Hotfix Casos Test

Solucionado error de nombres de casos test, el cual no permitía completar uno de los casos test implementados